### PR TITLE
changes current_folder to a helper method instead of an instance

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,7 +1,7 @@
 class Admin::DashboardController < ApplicationController
 before_action :authorize!
 
-  def dashboard 
+  def index
     @uploads = Upload.all
     @users = User.all
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,14 @@ require "zip"
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   helper_method :current_user
+  helper_method :current_folder
 
   def current_user
     @user ||= user_decorator if session[:user_id]
+  end
+
+  def current_folder
+    @current_folder ||= Folder.find(session[:current_folder_id]) if session[:current_folder_id]
   end
 
   def user_decorator

--- a/app/controllers/folders/collaborations_controller.rb
+++ b/app/controllers/folders/collaborations_controller.rb
@@ -1,19 +1,19 @@
 class Folders::CollaborationsController < ApplicationController
+  before_action :current_folder
+
   def new
-    @current_folder = Folder.find(params[:folder_id])
-    @collaboration  = @current_folder.collaborations.new
+    @collaboration  = current_folder.collaborations.new
   end
 
   def create
-    @current_folder = Folder.find(params[:folder_id])
-    @collaboration  = @current_folder.collaborations.new
+    @collaboration  = current_folder.collaborations.new
     @collaboration.user = User.find_by_username(params[:collaboration][:user])
     if @collaboration.save
-      flash[:success] = "You shared #{@current_folder.name} with #{@collaboration.user.username}!"
-      redirect_to folder_path(@current_folder)
+      flash[:success] = "You shared #{current_folder.name} with #{@collaboration.user.username}!"
+      redirect_to folder_path(current_folder)
     else
       flash[:danger] = "User not found, please try again."
-      redirect_to folder_share_path(@current_folder)
+      redirect_to folder_share_path(current_folder)
     end
   end
 

--- a/app/controllers/folders_controller.rb
+++ b/app/controllers/folders_controller.rb
@@ -1,13 +1,14 @@
 class FoldersController < ApplicationController
-before_action :authorize!
+  before_action :authorize!
+  after_action :current_folder
 
   def show
-    @current_folder = Folder.find(params[:id])
+    session[:current_folder_id] = params[:id]
     @file = Upload.new
   end
 
   def new
-    @current_folder = Folder.find(params[:id])
+    session[:current_folder_id] = params[:id]
     @folder = Folder.new
   end
 
@@ -17,9 +18,8 @@ before_action :authorize!
       flash[:success] = "#{@folder.name} Successfully Created"
       redirect_to folder_path(@folder)
     else
-      @current_folder = Folder.find(params[:id])
       flash[:danger] = "Incorrect Entry"
-      redirect_to new_folder_path(@current_folder)
+      redirect_to new_folder_path(current_folder)
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,7 +10,7 @@ class SessionsController < ApplicationController
         redirect_to admin_dashboard_path
       else
         flash[:success] = "#{user.first_name} Has Successfully Logged In"
-        redirect_to home_path
+        redirect_to folio_path
       end
     else
       flash[:error] = "Incorrect entry"

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -4,10 +4,10 @@ class UploadsController < ApplicationController
     upload = Upload.new(upload_params)
     if upload.save
       flash[:success] = "Your file has been uploaded!"
-      redirect_to home_path
+      redirect_to folio_path
     else
       flash[:danger] = "Please try uploading again"
-      redirect_to home_path
+      redirect_to folio_path
     end
   end
 
@@ -26,7 +26,7 @@ class UploadsController < ApplicationController
       flash[:danger] = "Please try uploading again"
     end
     if Folder.find_by(user: current_user, id: params[:id])
-      redirect_to home_path
+      redirect_to folio_path
     else
       redirect_to folder_path(Folder.find(params[:id]))
     end
@@ -40,7 +40,7 @@ class UploadsController < ApplicationController
       redirect_to admin_dashboard_path
     else
       flash[:danger] = "File deleted."
-      redirect_to home_path
+      redirect_to folio_path
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
-
   before_action :authorize!, only: [:show, :index, :edit, :update]
+  after_action :current_folder, only: :index
 
   def new
     @user = User.new
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
     if @user.save
       @user.registered_user
       session[:user_id] = @user.id
-      redirect_to home_path
+      redirect_to folio_path
     else
       flash[:danger] = "Please fill in every field to create an account."
       render :new
@@ -22,7 +22,7 @@ class UsersController < ApplicationController
   end
 
   def index
-    @current_folder = current_user.root_folder
+    session[:current_folder_id] = current_user.root_folder.id
     @folder = Folder.new
     @file = Upload.new
   end
@@ -36,7 +36,7 @@ class UsersController < ApplicationController
     @user.update_attributes(user_params)
     @user.update_attribute(:password, params[:user][:new_password])
     flash[:success] = "Account Successfully Updated!"
-    redirect_to home_path
+    redirect_to folio_path
   end
 
   private

--- a/app/services/permission.rb
+++ b/app/services/permission.rb
@@ -32,7 +32,7 @@ private
     return true if controller == "admin/dashboard" && action.in?("dashboard")
     return true if controller == "users" && action.in?(%w(index edit update show))
     return true if controller == "folders" && action.in?(%(show new create))
-    return true if controller == "uploads" && action.in?(%(new create show destroy))    
+    return true if controller == "uploads" && action.in?(%(new create show destroy))
   end
 
   def user_activated_permissions

--- a/app/views/folders/collaborations/new.html.erb
+++ b/app/views/folders/collaborations/new.html.erb
@@ -1,5 +1,5 @@
 <div class="center">
-  <h2>Share "<%= link_to @current_folder.name, folder_path(@current_folder) %>" with:</h2>
+  <h2>Share "<%= link_to current_folder.name, folder_path(current_folder) %>" with:</h2>
   <div class="center">
     <%= form_for :collaboration, url: folder_share_path do |f| %>
       <div class="container">

--- a/app/views/folders/new.html.erb
+++ b/app/views/folders/new.html.erb
@@ -3,6 +3,6 @@
 <%= form_for @folder do |f| %>
   <%= f.text_field :name, placeholder: "Folder Name" %>
   <%= f.text_field :user_id, value: "#{current_user.id}", type: :hidden %>
-  <%= f.text_field :parent_id, value: "#{@current_folder.id}", type: :hidden %>
+  <%= f.text_field :parent_id, value: "#{current_folder.id}", type: :hidden %>
   <%= f.submit "Create Folder" %>
 <% end %>

--- a/app/views/folders/show.html.erb
+++ b/app/views/folders/show.html.erb
@@ -1,19 +1,19 @@
-<h1><%= @current_folder.name %></h1>
+<h1><%= current_folder.name %></h1>
 
 <table>
   <tr>
     <td>
-      <%= link_to "Create New Folder", new_folder_path(@current_folder), class: "btn" %>
+      <%= link_to "Create New Folder", new_folder_path(current_folder), class: "btn" %>
     </td>
     <td>
       <%= render partial: "shared/upload_form" %>
     </td>
     <td>
-      <%= link_to "Download", folder_download_path(@current_folder), class: "btn" %>
+      <%= link_to "Download", folder_download_path(current_folder), class: "btn" %>
     </td>
   </tr>
 </table>
 <br>
 <%= render partial: "shared/breadcrumbs" %>
 <br>
-<%= render partial: "shared/data_table" %>
+<%= render partial: "shared/owned_table" %>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,10 +1,10 @@
 <div class="breadcrumbs">
-  <% @current_folder.ancestors.each do |f| %>
+  <% current_folder.ancestors.each do |f| %>
     <div class="box">
       <%= link_to f.name, folder_path(f) %>
     </div>
   <% end %>
   <div class="box">
-    <%= @current_folder.name %>
+    <%= current_folder.name %>
   </div>
 </div>

--- a/app/views/shared/_owned_table.html.erb
+++ b/app/views/shared/_owned_table.html.erb
@@ -12,7 +12,7 @@
 
   <tbody>
     <tr>
-      <% @current_folder.children.each do |child| %>
+      <% current_folder.children.each do |child| %>
         <td>
           <%= link_to child.name, child.class == Upload ? upload_path(child) : folder_path(child) %>
         </td>
@@ -30,7 +30,7 @@
         <td><%= child.display_privacy %></td>
         <td>
           <% if child.class == Upload %>
-            <%= link_to "Make #{child.opposite_privacy}", upload_path(@current_folder, child), method: :put, class: "btn"  %>
+            <%= link_to "Make #{child.opposite_privacy}", upload_path(current_folder, child), method: :put, class: "btn"  %>
           <% end %>
         </td>
       </tr>

--- a/app/views/shared/_upload_form.html.erb
+++ b/app/views/shared/_upload_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_for @file do |f| %>
    <%= f.file_field :attachment %>
-   <%= f.text_field :folder_id, value: "#{@current_folder.id}", type: :hidden %>
+   <%= f.text_field :folder_id, value: "#{current_folder.id}", type: :hidden %>
    <%= f.submit "Upload File" %>
  <% end %>

--- a/app/views/shared/_user_nav.html.erb
+++ b/app/views/shared/_user_nav.html.erb
@@ -2,7 +2,7 @@
     <nav>
       <div class="container">
         <div class="nav-wrapper">
-          <%= link_to "Folio Share", home_path, class: "brand-logo" %>
+          <%= link_to "Folio Share", folio_path, class: "brand-logo" %>
          <ul class="right hide-on-med-and-down">
           <li><%= link_to current_user.full_name, user_path(current_user) %></li>
           <li><%= link_to "Edit Account Details", edit_user_path(current_user) %></li>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,13 +3,13 @@
 <table>
   <tr>
     <td>
-      <%= link_to "Create New Folder", new_folder_path(@current_folder), class: "btn" %>
+      <%= link_to "Create New Folder", new_folder_path(current_folder), class: "btn" %>
     </td>
     <td>
       <%= render partial: "shared/upload_form" %>
     </td>
     <td>
-      <%= link_to "Download", folder_download_path(@current_folder), class: "btn" %>
+      <%= link_to "Download", folder_download_path(current_folder), class: "btn" %>
     </td>
   </tr>
 </table>
@@ -17,7 +17,7 @@
 <br>
 <%= render partial: "shared/breadcrumbs" %>
 <br>
-<%= render partial: "shared/data_table" %>
+<%= render partial: "shared/owned_table" %>
 
 <% unless current_user.shared_on.first.nil? %>
   <%= render partial: "shared/shared_table" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,13 @@
 Rails.application.routes.draw do
   get "/", to: "welcome#show"
-  get "/home", to: "users#index"
+  get "/Folio", to: "users#index", as: "folio"
   get "/login", to: "sessions#new"
   post "/login", to: "sessions#create"
   delete "/logout", to: "sessions#destroy"
 
   # admin
   namespace :admin do
-    get '/dashboard', to: 'dashboard#dashboard'
+    get '/dashboard', to: 'dashboard#indexs'
     resources :users, only: [:update, :show]
   end
 
@@ -20,21 +20,18 @@ Rails.application.routes.draw do
   # users
   resources :users, only: [:new, :create, :edit, :update, :show]
 
-
+  # folders
   resources :folders, path: :f, only: [:show]
   resources :folders, path: "f/:id", only: [:new, :create]
   resources :folders, path: :f, only: [:show] do
     get "/share", to: "folders/collaborations#new"
     post "/share", to: "folders/collaborations#create"
-    # resources :collaborations, only: :create
   end
-  
   get "/f/:id/download", to: "folders/download#index", as: "folder_download"
 
   # uploads, comments & download
   resources :uploads, path: :u, only: [:new, :create, :show, :update, :destroy]
   get "/u/:id/download", to: "uploads/download#index", as: "upload_download"
-
   resources :uploads, path: :u, only: [:show] do
     resources :comments, only: [:create]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   # admin
   namespace :admin do
-    get '/dashboard', to: 'dashboard#indexs'
+    get '/dashboard', to: 'dashboard#index'
     resources :users, only: [:update, :show]
   end
 

--- a/spec/features/admin/admin_clicks_admin_navbar_link_spec.rb
+++ b/spec/features/admin/admin_clicks_admin_navbar_link_spec.rb
@@ -9,7 +9,7 @@ feature "admin visit user index(show) page" do
       controller = ApplicationController
       allow_any_instance_of(controller).to receive(:current_user).and_return(admin)
 
-      visit home_path
+      visit folio_path
 
       click_on "Admin"
       expect(current_path).to eq(admin_dashboard_path)

--- a/spec/features/user/user_can_create_folder_in_root_spec.rb
+++ b/spec/features/user/user_can_create_folder_in_root_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "User" do
       controller = ApplicationController
       allow_any_instance_of(controller).to receive(:current_user).and_return(user)
 
-      visit home_path
+      visit folio_path
       expect(page).to_not have_content("Pictures")
       click_on "Create New Folder"
 
@@ -28,7 +28,7 @@ RSpec.feature "User" do
       root = user.folders.first
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
-      visit home_path
+      visit folio_path
       expect(page).to_not have_content("Pictures")
       click_on "Create New Folder"
 

--- a/spec/features/user/user_can_update_account_spec.rb
+++ b/spec/features/user/user_can_update_account_spec.rb
@@ -7,7 +7,7 @@ describe "As a registered user, when I am logged in" do
 
     allow_any_instance_of(controller).to receive(:current_user).and_return(user)
 
-    visit home_path
+    visit folio_path
 
     click_on "Edit Account Details"
     expect(current_path).to eq(edit_user_path(user))
@@ -19,7 +19,7 @@ describe "As a registered user, when I am logged in" do
 
     click_on "Update"
 
-    expect(current_path).to eq(home_path)
+    expect(current_path).to eq(folio_path)
 
     within(".alert-success") do
       expect(page).to have_content("Account Successfully Updated!")


### PR DESCRIPTION
This implements current_folder as a helper method so we aren't passing in so many instance variables to the views.

This also changes:
- `/home` --> `/Folio` (and updates all instances of `home_path` to `folio_path`
- `#dashboard` method on the Dashboard controller --> `#index` to be restful
- partial for the table of owned folders and uploads from `_data_table` to `_owned_table` to be more descriptive compared with new `_shared_table` partial.