### PR TITLE
Fixes folio breadcrumb

### DIFF
--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,7 +1,7 @@
 <div class="breadcrumbs">
   <% current_folder.ancestors.each do |f| %>
     <div class="box">
-      <%= link_to f.name, folder_path(f) %>
+      <%= link_to f.name, folio_path %>
     </div>
   <% end %>
   <div class="box">

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,10 +1,17 @@
 <div class="breadcrumbs">
+  <div class="box">
+    <%= link_to "Folio", folio_path %>
+  </div>
   <% current_folder.ancestors.each do |f| %>
+  <% unless f.name == "Folio" %>
     <div class="box">
-      <%= link_to f.name, folio_path %>
+        <%= link_to f.name, folder_path(f) %>
+    </div>
+    <% end %>
+  <% end %>
+  <% unless current_folder.name == "Folio" %>
+    <div class="box">
+        <%= current_folder.name %>
     </div>
   <% end %>
-  <div class="box">
-    <%= current_folder.name %>
-  </div>
 </div>

--- a/app/views/shared/_owned_table.html.erb
+++ b/app/views/shared/_owned_table.html.erb
@@ -28,7 +28,6 @@
           <%= link_to child.name, child.class == Upload ? upload_path(child) : folder_path(child) %>
         </td>
         <td class="table_data_center">
-        <td>
           <%= number_to_human_size(child.size) %>
         </td>
         <td class="table_data_center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
 
   # folders
   resources :folders, path: "f/:id", only: [:new, :create]
-  resources :folders, path: :f, only: [:show, :update] do
+  resources :folders, path: :f, only: [:show, :update, :destroy] do
     get "/share", to: "folders/collaborations#new"
     post "/share", to: "folders/collaborations#create"
   end

--- a/spec/features/user/user_can_create_folder_in_root_spec.rb
+++ b/spec/features/user/user_can_create_folder_in_root_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "User" do
 
       expect(current_path).to eq("/f/#{Folder.last.id}")
       within("div.breadcrumbs") do
-        expect(page).to have_link("Folio", href: folder_path(root))
+        expect(page).to have_link("Folio", href: folio_path)
         expect(page).to have_content("Pictures")
       end
     end

--- a/spec/features/user/user_can_delete_a_folder_spec.rb
+++ b/spec/features/user/user_can_delete_a_folder_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 describe "a registered user" do
   it "can delete a folder they own" do
     user    = create(:user)
+    user = UserDecorator.new(user)
+    user.roles.create(name: "activated")
+    user.roles.create(name: "registered user")
+    root = user.folders.first
     folder  = create(:folder, name: "Flowers", parent: user.root_folder)
 
     visit "/login"
@@ -15,7 +19,7 @@ describe "a registered user" do
     expect(current_path).to eq("/Folio")
     expect(page).to have_content("Flowers")
 
-    click_on "Delete"
+    click_button "Delete"
 
     expect(current_path).to eq("/Folio")
     expect(page).to_not have_content("Flowers")

--- a/spec/features/user/user_creates_nested_folder_spec.rb
+++ b/spec/features/user/user_creates_nested_folder_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "User" do
 
       expect(current_path).to eq("/f/#{Folder.last.id}")
       within("div.breadcrumbs") do
-        expect(page).to have_link("Folio", href: folder_path(root))
+        expect(page).to have_link("Folio", href: folio_path)
         expect(page).to have_link(subfolder.name, href: folder_path(subfolder))
         expect(page).to have_content("Puppies")
       end


### PR DESCRIPTION
This PR does multiple things...
-fixes Folio breadcrumb to navigate to 'users#index' instead of 'folders#show'
-fixes styling on Folio page table that had an extra <td> that was throwing off the table

-fixes deleting a folder; it was missing the route
-fixes two of the failing tests