### PR TITLE
Fixes folder show styling

### DIFF
--- a/app/assets/stylesheets/foundations.scss
+++ b/app/assets/stylesheets/foundations.scss
@@ -129,7 +129,8 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .download_folio_icon {
-
+  vertical-align: middle;
+  display: inline;
 }
 
 .material-icons {

--- a/app/views/folders/show.html.erb
+++ b/app/views/folders/show.html.erb
@@ -8,12 +8,14 @@
     <td>
       <%= render partial: "shared/upload_form" %>
     </td>
-    <td>
-      <%= link_to "Download", folder_download_path(current_folder), class: "btn" %>
-    </td>
   </tr>
 </table>
 <br>
-<%= render partial: "shared/breadcrumbs" %>
+<div class="breadcrumb_folio">
+  <%= render partial: "shared/breadcrumbs" %>
+</div>
+<div class="download_folio_icon">
+  <%= link_to folder_download_path(current_folder) do %><span><i class="material-icons">file_download</i></span><% end %>
+</div>
 <br>
 <%= render partial: "shared/owned_table" %>


### PR DESCRIPTION
This styling adds the download folder icon link in place of the button, just like we have on the Folio page.